### PR TITLE
add: support for microsoft v1 endpoints which requires resource for token aud

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -40,7 +40,7 @@ class ClientCredentialsOAuthClient {
 
   private readonly clientSecret: string;
 
-  private readonly resource: string;
+  private readonly scope: string;
 
   private readonly mut = new Mutex();
 
@@ -65,14 +65,14 @@ class ClientCredentialsOAuthClient {
     clientId: string,
     clientSecret: string,
     retrieveType: TokenRetrieveType = "header",
-    resource?: string,
+    scope?: string,
   ) {
 
     this.tokenUrl = tokenUrl;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tokenRetrieveType = retrieveType;
-    this.resource = resource;
+    this.scope = scope;
   }
 
   /**
@@ -87,8 +87,8 @@ class ClientCredentialsOAuthClient {
     let response = undefined;
 
     if (this.tokenRetrieveType === "form") {
-      if (this.resource) {
-        params.append("resource", this.resource);
+      if (this.scope) {
+        params.append("resource", this.scope);
       }
       params.append("client_id", this.clientId);
       params.append("client_secret", this.clientSecret);

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -83,14 +83,13 @@ class ClientCredentialsOAuthClient {
   private async fetchOAuthResponse(): Promise<any> {
     const params = new SearchParams();
     params.append("grant_type", S_CLIENT_CREDENTIALS);
-    if (this.resource) {
-      params.append("resource", this.resource);
-    }
 
     let response = undefined;
 
     if (this.tokenRetrieveType === "form") {
-
+      if (this.resource) {
+        params.append("resource", this.resource);
+      }
       params.append("client_id", this.clientId);
       params.append("client_secret", this.clientSecret);
       response = await fetch(this.tokenUrl, {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -88,7 +88,7 @@ class ClientCredentialsOAuthClient {
 
     if (this.tokenRetrieveType === "form") {
       if (this.scope) {
-        params.append("resource", this.scope);
+        params.append("scope", this.scope);
       }
       params.append("client_id", this.clientId);
       params.append("client_secret", this.clientSecret);

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -40,6 +40,8 @@ class ClientCredentialsOAuthClient {
 
   private readonly clientSecret: string;
 
+  private readonly resource: string;
+
   private readonly mut = new Mutex();
 
   private token: string;
@@ -56,18 +58,21 @@ class ClientCredentialsOAuthClient {
    * @param clientId oauth client id
    * @param clientSecret oauth client secret
    * @param retrieveType the clientId and clientSecret is put into header or form body
+   * @param [resource] the resource to target
    */
   constructor(
     tokenUrl: string,
     clientId: string,
     clientSecret: string,
-    retrieveType: TokenRetrieveType = "header"
+    retrieveType: TokenRetrieveType = "header",
+    resource?: string,
   ) {
 
     this.tokenUrl = tokenUrl;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.tokenRetrieveType = retrieveType;
+    this.resource = resource;
   }
 
   /**
@@ -78,6 +83,9 @@ class ClientCredentialsOAuthClient {
   private async fetchOAuthResponse(): Promise<any> {
     const params = new SearchParams();
     params.append("grant_type", S_CLIENT_CREDENTIALS);
+    if (this.resource) {
+      params.append("resource", this.resource);
+    }
 
     let response = undefined;
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -198,6 +198,8 @@ export class OData {
           credential.tokenUrl,
           credential.clientId,
           credential.clientSecret,
+          credential.tokenRetrieveType,
+          credential.scope
         );
       }
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -198,6 +198,8 @@ export class OData {
           credential.tokenUrl,
           credential.clientId,
           credential.clientSecret,
+          credential.tokenRetrieveType,
+          credential.resource
         );
       }
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -198,8 +198,6 @@ export class OData {
           credential.tokenUrl,
           credential.clientId,
           credential.clientSecret,
-          credential.tokenRetrieveType,
-          credential.scope
         );
       }
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -199,7 +199,7 @@ export class OData {
           credential.clientId,
           credential.clientSecret,
           credential.tokenRetrieveType,
-          credential.resource
+          credential.scope
         );
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -224,9 +224,9 @@ export interface Credential {
   tokenRetrieveType?: TokenRetrieveType;
 
   /**
-   * traget resource 
+   * traget scope 
    */
-  resource?: string;
+  scope?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,6 +222,11 @@ export interface Credential {
    * oauth token retrieve type
    */
   tokenRetrieveType?: TokenRetrieveType;
+
+  /**
+   * traget resource 
+   */
+  resource?: string;
 }
 
 /**


### PR DESCRIPTION
Context: Azure and Dynamics365
Resource parameter depicts the identifier of the WebAPI that your client wants to access on behalf of the user. Most flows in OAuth involve 4 parties, the resource owner (aka user), the client (aka app), the authority (aka identity provider) and the resource (aka webapi). The audience of the access token that the authority generates is the resource identifier.

